### PR TITLE
Adjustments

### DIFF
--- a/ScrapMeat2.cs
+++ b/ScrapMeat2.cs
@@ -40,7 +40,7 @@ namespace Eco.Mods.TechTree
                     })
             };
             this.ExperienceOnCraft = 5;  
-            this.LaborInCalories = CreateLaborInCaloriesValue(120, typeof(ButcherySkill)); 
+            this.LaborInCalories = CreateLaborInCaloriesValue(15, typeof(ButcherySkill)); 
             this.CraftMinutes = CreateCraftTimeValue(typeof(AdvancedScrapMeatRecipe), 1, typeof(ButcherySkill), typeof(ButcheryFocusedSpeedTalent), typeof(ButcheryParallelSpeedTalent));     
             this.ModsPreInitialize();
             this.Initialize(Localizer.DoStr("Scrap Meat"), typeof(AdvancedScrapMeatRecipe));


### PR DESCRIPTION
Electric Tables/Machines traditionally require less calories than their manual/early game counterparts and also offer better results. Butchery Table takes 15 calories for it's scrap meat recipe. It's only fair that this recipe takes 15 cals at most.